### PR TITLE
z00a: overlay: Update power profile from 2.20.90

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -73,4 +73,10 @@
         <value>563</value>
     </array>
     <item name="battery.capacity">3000</item>
+    <array name="camera.mode">
+        <value>60</value>
+        <value>60</value>
+        <value>310</value>
+        <value>190</value>
+    </array>
 </device>


### PR DESCRIPTION
This adds camera power information which I don't think we're
going to use, but just staying up-to-date.

Change-Id: I95b5d8d0097bf4ddd9d4c5cdd1a9b9e808175062
